### PR TITLE
Add update tools for orders, warranties and shipments

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ This server provides integration with StateSet's issue operations system through
 The server exposes a variety of MCP tools for creating, updating and retrieving records:
 
 - `stateset_create_rma`, `stateset_update_rma`, `stateset_get_rma`
-- `stateset_create_order`, `stateset_get_order`
-- `stateset_create_warranty`, `stateset_get_warranty`
-- `stateset_create_shipment`, `stateset_get_shipment`
+- `stateset_create_order`, `stateset_update_order`, `stateset_get_order`
+- `stateset_create_warranty`, `stateset_update_warranty`, `stateset_get_warranty`
+- `stateset_create_shipment`, `stateset_update_shipment`, `stateset_get_shipment`
 - `stateset_create_bill_of_materials`, `stateset_update_bill_of_materials`, `stateset_get_bill_of_materials`
 - `stateset_create_work_order`, `stateset_update_work_order`, `stateset_get_work_order`
 - `stateset_create_manufacturer_order`, `stateset_update_manufacturer_order`, `stateset_get_manufacturer_order`


### PR DESCRIPTION
## Summary
- implement UpdateOrderArgs, UpdateWarrantyArgs, and UpdateShipmentArgs
- support new updateOrder/updateWarranty/updateShipment API calls
- expose corresponding tools and list them in server prompt
- include new tools when listing available tools
- document new tool names

## Testing
- `npm test` *(fails: Error: no test specified)*