### PR TITLE
Add product management tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,11 @@ The server exposes a variety of MCP tools for creating, updating, deleting and r
 - `stateset_create_manufacturer_order`, `stateset_update_manufacturer_order`, `stateset_delete_manufacturer_order`, `stateset_get_manufacturer_order`
 - `stateset_create_invoice`, `stateset_update_invoice`, `stateset_delete_invoice`, `stateset_get_invoice`
 - `stateset_create_payment`, `stateset_update_payment`, `stateset_delete_payment`, `stateset_get_payment`
+- `stateset_create_product`, `stateset_update_product`, `stateset_delete_product`, `stateset_get_product`
 - `stateset_create_customer`, `stateset_update_customer`, `stateset_delete_customer`, `stateset_get_customer`
 - `stateset_list_rmas`, `stateset_list_orders`, `stateset_list_warranties`, `stateset_list_shipments`
 - `stateset_list_bill_of_materials`, `stateset_list_work_orders`, `stateset_list_manufacturer_orders`
-- `stateset_list_invoices`, `stateset_list_payments`, `stateset_list_customers`
+- `stateset_list_invoices`, `stateset_list_payments`, `stateset_list_products`, `stateset_list_customers`
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- add CRUD functions for products to the MCP client
- expose product tools for create/update/delete/get/list
- support `stateset-product://` resource template
- document new product tools

## Testing
- `npm test` *(fails: Error: no test specified)*