### PR TITLE
Add API metrics tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The server exposes a variety of MCP tools for creating, updating, deleting and r
 - `stateset_create_customer`, `stateset_update_customer`, `stateset_delete_customer`, `stateset_get_customer`
 - `stateset_list_rmas`, `stateset_list_orders`, `stateset_list_warranties`, `stateset_list_shipments`
 - `stateset_list_bill_of_materials`, `stateset_list_work_orders`, `stateset_list_manufacturer_orders`
-- `stateset_list_invoices`, `stateset_list_payments`, `stateset_list_products`, `stateset_list_inventories`, `stateset_list_customers`
+- `stateset_list_invoices`, `stateset_list_payments`, `stateset_list_products`, `stateset_list_inventories`, `stateset_list_customers`, `stateset_get_api_metrics`
 
 ## Usage
 

--- a/index.ts
+++ b/index.ts
@@ -373,6 +373,8 @@ interface ListArgs {
   per_page?: number;
 }
 
+interface GetApiMetricsArgs {}
+
 // Rate Limiter
 class RateLimiter {
   private readonly requestsPerHour: number;
@@ -1028,6 +1030,10 @@ class StateSetMCPClient {
     );
     return this.enrichListResponse(response.data);
   }
+
+  getApiMetrics(): { apiMetrics: RateLimiterMetrics } {
+    return { apiMetrics: this.rateLimiter.getMetrics() };
+  }
 }
 
 // Zod Schemas
@@ -1401,6 +1407,8 @@ const ListArgsSchema = z.object({
   per_page: z.number().positive().optional(),
 });
 
+const GetApiMetricsArgsSchema = z.object({});
+
 
 // Tool Definitions
 const createRMATool: Tool = {
@@ -1763,6 +1771,12 @@ const listCustomersTool: Tool = {
   inputSchema: ListArgsSchema.shape as any,
 };
 
+const getApiMetricsTool: Tool = {
+  name: "stateset_get_api_metrics",
+  description: "Returns API rate limiter metrics",
+  inputSchema: GetApiMetricsArgsSchema.shape as any,
+};
+
 
 // Resource Templates
 const resourceTemplates: ResourceTemplate[] = [
@@ -2078,6 +2092,8 @@ async function main(): Promise<void> {
             return await client.listInventories(ListArgsSchema.parse(request.params.arguments));
           case "stateset_list_customers":
             return await client.listCustomers(ListArgsSchema.parse(request.params.arguments));
+          case "stateset_get_api_metrics":
+            return client.getApiMetrics();
 
           default:
             throw new Error(`Unknown tool: ${request.params.name}`);
@@ -2196,6 +2212,7 @@ async function main(): Promise<void> {
         listProductsTool,
         listInventoriesTool,
         listCustomersTool,
+        getApiMetricsTool,
       ],
     }));
 


### PR DESCRIPTION
## Summary
- extend MCP server with `stateset_get_api_metrics`
- document the new tool

## Testing
- `npm test` *(fails: Error: no test specified)*