### PR TITLE
Add purchase order and ASN operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,27 +6,39 @@ This server provides integration with StateSet's issue operations system through
 
 ## Tools
 
-The server exposes a variety of MCP tools for creating, updating, deleting and retrieving records:
+The server exposes a comprehensive set of MCP tools grouped by domain.
 
-- `stateset_create_rma`, `stateset_update_rma`, `stateset_delete_rma`, `stateset_get_rma`
+### Orders & Returns
 - `stateset_create_order`, `stateset_update_order`, `stateset_delete_order`, `stateset_get_order`
-- `stateset_create_warranty`, `stateset_update_warranty`, `stateset_delete_warranty`, `stateset_get_warranty`
+- `stateset_create_sales_order`, `stateset_update_sales_order`, `stateset_delete_sales_order`, `stateset_get_sales_order`
+- `stateset_create_rma`, `stateset_update_rma`, `stateset_delete_rma`, `stateset_get_rma`
+- `stateset_create_purchase_order`, `stateset_update_purchase_order`, `stateset_delete_purchase_order`, `stateset_get_purchase_order`
+
+### Fulfillment & Production
 - `stateset_create_shipment`, `stateset_update_shipment`, `stateset_delete_shipment`, `stateset_get_shipment`
+- `stateset_create_fulfillment_order`, `stateset_update_fulfillment_order`, `stateset_delete_fulfillment_order`, `stateset_get_fulfillment_order`
+- `stateset_create_item_receipt`, `stateset_update_item_receipt`, `stateset_delete_item_receipt`, `stateset_get_item_receipt`
 - `stateset_create_bill_of_materials`, `stateset_update_bill_of_materials`, `stateset_delete_bill_of_materials`, `stateset_get_bill_of_materials`
 - `stateset_create_work_order`, `stateset_update_work_order`, `stateset_delete_work_order`, `stateset_get_work_order`
 - `stateset_create_manufacturer_order`, `stateset_update_manufacturer_order`, `stateset_delete_manufacturer_order`, `stateset_get_manufacturer_order`
-- `stateset_create_invoice`, `stateset_update_invoice`, `stateset_delete_invoice`, `stateset_get_invoice`
- - `stateset_create_payment`, `stateset_update_payment`, `stateset_delete_payment`, `stateset_get_payment`
- - `stateset_create_sales_order`, `stateset_update_sales_order`, `stateset_delete_sales_order`, `stateset_get_sales_order`
- - `stateset_create_fulfillment_order`, `stateset_update_fulfillment_order`, `stateset_delete_fulfillment_order`, `stateset_get_fulfillment_order`
- - `stateset_create_item_receipt`, `stateset_update_item_receipt`, `stateset_delete_item_receipt`, `stateset_get_item_receipt`
- - `stateset_create_cash_sale`, `stateset_update_cash_sale`, `stateset_delete_cash_sale`, `stateset_get_cash_sale`
- - `stateset_create_product`, `stateset_update_product`, `stateset_delete_product`, `stateset_get_product`
+- `stateset_create_asn`, `stateset_update_asn`, `stateset_delete_asn`, `stateset_get_asn`
+
+### Inventory & Products
+- `stateset_create_product`, `stateset_update_product`, `stateset_delete_product`, `stateset_get_product`
 - `stateset_create_inventory`, `stateset_update_inventory`, `stateset_delete_inventory`, `stateset_get_inventory`
+
+### Financial
+- `stateset_create_invoice`, `stateset_update_invoice`, `stateset_delete_invoice`, `stateset_get_invoice`
+- `stateset_create_payment`, `stateset_update_payment`, `stateset_delete_payment`, `stateset_get_payment`
+- `stateset_create_cash_sale`, `stateset_update_cash_sale`, `stateset_delete_cash_sale`, `stateset_get_cash_sale`
+
+### Customers
 - `stateset_create_customer`, `stateset_update_customer`, `stateset_delete_customer`, `stateset_get_customer`
- - `stateset_list_rmas`, `stateset_list_orders`, `stateset_list_sales_orders`, `stateset_list_warranties`, `stateset_list_shipments`, `stateset_list_fulfillment_orders`, `stateset_list_item_receipts`, `stateset_list_cash_sales`
- - `stateset_list_bill_of_materials`, `stateset_list_work_orders`, `stateset_list_manufacturer_orders`
- - `stateset_list_invoices`, `stateset_list_payments`, `stateset_list_products`, `stateset_list_inventories`, `stateset_list_customers`, `stateset_get_api_metrics`
+
+### Listing Operations
+- `stateset_list_rmas`, `stateset_list_orders`, `stateset_list_sales_orders`, `stateset_list_warranties`, `stateset_list_shipments`, `stateset_list_fulfillment_orders`, `stateset_list_item_receipts`, `stateset_list_cash_sales`
+- `stateset_list_purchase_orders`, `stateset_list_asns`, `stateset_list_bill_of_materials`, `stateset_list_work_orders`, `stateset_list_manufacturer_orders`
+- `stateset_list_invoices`, `stateset_list_payments`, `stateset_list_products`, `stateset_list_inventories`, `stateset_list_customers`, `stateset_get_api_metrics`
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- support creating, updating, reading, deleting, and listing purchase orders and ASNs
- document new MCP tools in README
- include purchase orders and ASNs in server prompt and resource templates

## Testing
- `npm test` *(fails: Error: no test specified)*