### PR TITLE
Improve server configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Ensure the following environment variables are set before running the server:
 - `STATESET_API_KEY` – your API key (required)
 - `STATESET_BASE_URL` – base URL for the StateSet API (defaults to `https://api.stateset.io/v1`)
 - `REQUESTS_PER_HOUR` – rate limit for outgoing requests (defaults to `1000`)
+- `API_TIMEOUT_MS` – request timeout in milliseconds (defaults to `10000`)
 
 Install dependencies with `npm install` and start the server using:
 

--- a/index.ts
+++ b/index.ts
@@ -32,6 +32,7 @@ interface Config {
   apiKey: string;
   baseUrl: string;
   requestsPerHour: number;
+  timeoutMs: number;
 }
 
 // Type definitions
@@ -641,7 +642,7 @@ class StateSetMCPClient {
         'Authorization': `Bearer ${config.apiKey}`,
         'Content-Type': 'application/json',
       },
-      timeout: 10000,
+      timeout: config.timeoutMs,
     });
 
     this.apiClient.interceptors.response.use(
@@ -2794,12 +2795,14 @@ async function main(): Promise<void> {
       STATESET_API_KEY: z.string().min(1, 'STATESET_API_KEY is required'),
       STATESET_BASE_URL: z.string().url().default('https://api.stateset.io/v1'),
       REQUESTS_PER_HOUR: z.coerce.number().positive().default(1000),
+      API_TIMEOUT_MS: z.coerce.number().positive().default(10000),
     }).parse(process.env);
 
     const config: Config = {
       apiKey: env.STATESET_API_KEY,
       baseUrl: env.STATESET_BASE_URL,
       requestsPerHour: env.REQUESTS_PER_HOUR,
+      timeoutMs: env.API_TIMEOUT_MS,
     };
 
     const client = new StateSetMCPClient(config);


### PR DESCRIPTION
## Summary
- allow configuring API timeout via new `API_TIMEOUT_MS` env var
- document the new environment variable

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684073f96724832e92c2ee9815076e5c